### PR TITLE
Ensure database directory is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,7 @@ Build and start services:
 docker-compose -f docker/docker-compose.yml up --build
 ```
 
+The backend stores its SQLite database in `backend/db`. The Dockerfile and
+startup routines will create this folder automatically if it does not exist.
+
 Backend runs at `http://localhost:8000`, frontend at `http://localhost:3000`.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY ./app /app/app
 COPY requirements.txt /app/
+RUN mkdir -p /app/db
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,6 +1,11 @@
-from .session import SessionLocal, engine
+from pathlib import Path
+from .session import SessionLocal, engine, SQLALCHEMY_DATABASE_URL
 from .base import Base
 
 
 def init_db():
+    """Initialize database and ensure database directory exists."""
+    if SQLALCHEMY_DATABASE_URL.startswith("sqlite:///"):
+        db_file = SQLALCHEMY_DATABASE_URL.split("sqlite:///", 1)[1]
+        Path(db_file).parent.mkdir(parents=True, exist_ok=True)
     Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
## Summary
- keep persistent database folder at `backend/db`
- create db folder during backend Docker build
- initialize the folder on startup to avoid missing path errors
- mention the database folder in the README

## Testing
- `python -m py_compile backend/app/db/__init__.py backend/app/db/session.py`

------
https://chatgpt.com/codex/tasks/task_e_687bb5a0aab88331a014835885469c3d