### PR TITLE
Add location FK to Activity model

### DIFF
--- a/backend/alembic/versions/0002_add_location_id_to_activity.py
+++ b/backend/alembic/versions/0002_add_location_id_to_activity.py
@@ -1,0 +1,15 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0002'
+down_revision = '0001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('activities', sa.Column('location_id', sa.String(), sa.ForeignKey('locations.id')))
+
+
+def downgrade():
+    op.drop_column('activities', 'location_id')

--- a/backend/app/models/activity.py
+++ b/backend/app/models/activity.py
@@ -17,7 +17,10 @@ class Activity(Base):
     start_time = Column(DateTime)
     end_time = Column(DateTime)
     location = Column(String)
+    location_id = Column(String, ForeignKey("locations.id"))
     notes = Column(String)
 
-    location_rel = relationship("Location", back_populates="activities")
+    location_rel = relationship(
+        "Location", back_populates="activities", foreign_keys=[location_id]
+    )
     horse = relationship("Horse", back_populates="activities")

--- a/backend/app/schemas/activity.py
+++ b/backend/app/schemas/activity.py
@@ -8,6 +8,7 @@ class ActivityBase(BaseModel):
     start_time: Optional[datetime] = None
     end_time: Optional[datetime] = None
     location: Optional[str] = None
+    location_id: Optional[str] = None
     notes: Optional[str] = None
 
 class ActivityCreate(ActivityBase):


### PR DESCRIPTION
## Summary
- link activities to locations using a `location_id` foreign key
- expose `location_id` in Activity schema
- add Alembic migration for the new field

## Testing
- `python -m py_compile backend/app/models/activity.py backend/app/schemas/activity.py backend/alembic/versions/0002_add_location_id_to_activity.py`


------
https://chatgpt.com/codex/tasks/task_e_687bb5afb5508331a23d773a71c5e464