### PR TITLE
Improve documentation for running migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,21 @@ docker-compose -f docker/docker-compose.yml up --build
 ```
 
 Backend runs at `http://localhost:8000`, frontend at `http://localhost:3000`.
+
+## Database and migrations
+
+Alembic manages database migrations. Run the migrations inside the backend
+service with:
+
+```bash
+docker-compose -f docker/docker-compose.yml run --rm backend alembic upgrade head
+```
+
+The SQLite database file lives at `backend/db/data.db` (inside the container it
+resides in `/app/db/data.db`).
+
+## Admin UI and demo data
+
+The admin data grid is served at `http://localhost:3000/grid`. You can populate
+the app with sample content by toggling "Demo data" in the UI before
+initialization.


### PR DESCRIPTION
## Summary
- document how to run Alembic migrations
- note SQLite file location
- mention demo-data toggle
- mention admin UI path

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687bb5c21d548331ba7622d70b1a2342