### PR TITLE
Add frontend entrypoint script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ docker-compose -f docker/docker-compose.yml up --build
 ```
 
 Backend runs at `http://localhost:8000`, frontend at `http://localhost:3000`.
+
+The frontend container runs an entrypoint script that installs dependencies if
+`node_modules` is missing before starting Vite.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,4 +13,4 @@ services:
       - ../frontend:/app
     ports:
       - "3000:3000"
-    command: npm run dev -- --host
+    command: ./entrypoint.sh

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+if [ ! -d node_modules ] || [ -z "$(ls -A node_modules 2>/dev/null)" ]; then
+  echo "Node modules missing, installing dependencies..."
+  npm install
+fi
+
+exec npm run dev -- --host


### PR DESCRIPTION
## Summary
- add a shell entrypoint for the frontend
- use that entrypoint in docker compose
- mention the auto-install behaviour in README

## Testing
- `docker-compose --version` *(fails: command not found)*
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb5a8fdb88331a90e14be5d776e39