### PR TITLE
Fix README merge markers and clarify setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,27 @@
 # EQTRv1
-#
-#Delmar Horse Management application.
-#
-## Development
-#
-#Build and start services:
-#
-#```bash
-#docker-compose -f docker/docker-compose.yml up --build
-#```
 
-#The backend stores its SQLite database in `backend/db`. The Dockerfile and
-#startup routines will create this folder automatically if it does not exist.
-#
-#Backend runs at `http://localhost:8000`, frontend at `http://localhost:3000`.
-#
-#<<<<<<< codex/add-entrypoint-script-for-frontend-service
-#The frontend container runs an entrypoint script that installs dependencies if
-#`node_modules` is missing before starting Vite.
-#=======
+Delmar Horse Management application.
+
+## Development
+
+### Build and start services
+
+```bash
+docker-compose -f docker/docker-compose.yml up --build
+```
+
+The backend stores its SQLite database in `backend/db`. This directory is created automatically when the containers start. Backend runs at `http://localhost:8000` and the frontend at `http://localhost:3000`. The frontend container runs an entrypoint script that installs dependencies if `node_modules` is missing before starting Vite.
+
 ### Database and migrations
 
-#Alembic manages database migrations. Run the migrations inside the backend
-#service with:
-#
-#```bash
-#docker-compose -f docker/docker-compose.yml run --rm backend alembic upgrade head
-#```
-#
-#The SQLite database file lives at `backend/db/data.db` (inside the container it
-#resides in `/app/db/data.db`).
-#
+Alembic manages database migrations. Apply them with:
+
+```bash
+docker-compose -f docker/docker-compose.yml run --rm backend alembic upgrade head
+```
+
+The SQLite database file lives at `backend/db/data.db` (inside the container it resides in `/app/db/data.db`).
+
 ### Admin UI and demo data
-#
-#The admin data grid is served at `http://localhost:3000/grid`. You can populate
-#the app with sample content by toggling "Demo data" in the UI before
-#initialization.
-#>>>>>>> main
+
+The admin data grid is served at `http://localhost:3000/grid`. You can populate the app with sample content by toggling "Demo data" in the UI before initialization.


### PR DESCRIPTION
## Summary
- remove merge conflict markers from the README
- document how to start the Docker services
- explain where the SQLite database lives and how to run migrations

## Testing
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=backend pytest backend/app/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_687bbebd4d608331abb674bbc4a202c6