### PR TITLE
Add foreign key constraints

### DIFF
--- a/backend/alembic/versions/0001_create_tables.py
+++ b/backend/alembic/versions/0001_create_tables.py
@@ -12,7 +12,7 @@ def upgrade():
         'horses',
         sa.Column('id', sa.String(), primary_key=True),
         sa.Column('name', sa.String(), nullable=False, unique=True),
-        sa.Column('owner_id', sa.String(), nullable=True),
+        sa.Column('owner_id', sa.String(), sa.ForeignKey('owners.id'), nullable=True),
         sa.Column('status', sa.String(), nullable=True),
         sa.Column('location', sa.String(), nullable=True),
         sa.Column('breed', sa.String(), nullable=True),
@@ -48,7 +48,7 @@ def upgrade():
     op.create_table(
         'activities',
         sa.Column('id', sa.String(), primary_key=True),
-        sa.Column('horse_id', sa.String(), nullable=False),
+        sa.Column('horse_id', sa.String(), sa.ForeignKey('horses.id'), nullable=False),
         sa.Column('activity_type', sa.String()),
         sa.Column('start_time', sa.DateTime()),
         sa.Column('end_time', sa.DateTime()),
@@ -59,8 +59,8 @@ def upgrade():
     op.create_table(
         'drug_tests',
         sa.Column('id', sa.String(), primary_key=True),
-        sa.Column('horse_id', sa.String()),
-        sa.Column('race_id', sa.String()),
+        sa.Column('horse_id', sa.String(), sa.ForeignKey('horses.id')),
+        sa.Column('race_id', sa.String(), sa.ForeignKey('races.id')),
         sa.Column('result', sa.String()),
         sa.Column('date', sa.Date()),
         sa.Column('notes', sa.String()),
@@ -69,7 +69,7 @@ def upgrade():
     op.create_table(
         'vet_records',
         sa.Column('id', sa.String(), primary_key=True),
-        sa.Column('horse_id', sa.String()),
+        sa.Column('horse_id', sa.String(), sa.ForeignKey('horses.id')),
         sa.Column('visit_date', sa.Date()),
         sa.Column('notes', sa.String()),
         sa.Column('injury_type', sa.String()),

--- a/backend/alembic/versions/0003_add_foreign_keys.py
+++ b/backend/alembic/versions/0003_add_foreign_keys.py
@@ -1,0 +1,23 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0003'
+down_revision = '0002'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_foreign_key('fk_horses_owner_id', 'horses', 'owners', ['owner_id'], ['id'])
+    op.create_foreign_key('fk_activities_horse_id', 'activities', 'horses', ['horse_id'], ['id'])
+    op.create_foreign_key('fk_drug_tests_horse_id', 'drug_tests', 'horses', ['horse_id'], ['id'])
+    op.create_foreign_key('fk_drug_tests_race_id', 'drug_tests', 'races', ['race_id'], ['id'])
+    op.create_foreign_key('fk_vet_records_horse_id', 'vet_records', 'horses', ['horse_id'], ['id'])
+
+
+def downgrade():
+    op.drop_constraint('fk_vet_records_horse_id', 'vet_records', type_='foreignkey')
+    op.drop_constraint('fk_drug_tests_race_id', 'drug_tests', type_='foreignkey')
+    op.drop_constraint('fk_drug_tests_horse_id', 'drug_tests', type_='foreignkey')
+    op.drop_constraint('fk_activities_horse_id', 'activities', type_='foreignkey')
+    op.drop_constraint('fk_horses_owner_id', 'horses', type_='foreignkey')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = test_*.py


### PR DESCRIPTION
## Summary
- add missing foreign key definitions to initial Alembic migration
- create follow-on migration to add these FKs for existing databases
- configure pytest to ignore non-test modules

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687bc06669d08331be6d1a756ed1468d