### PR TITLE
Add env var support for DB URL

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,10 +1,16 @@
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./db/data.db"
+SQLALCHEMY_DATABASE_URL = os.getenv(
+    "SQLALCHEMY_DATABASE_URL", "sqlite:///./db/data.db"
+)
 
 engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False}
+    if SQLALCHEMY_DATABASE_URL.startswith("sqlite")
+    else {},
 )
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build: ../backend
     volumes:
       - ../backend:/app
+    environment:
+      - SQLALCHEMY_DATABASE_URL=sqlite:///./db/data.db
     ports:
       - "8000:8000"
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload


### PR DESCRIPTION
## Summary
- allow configuration of `SQLALCHEMY_DATABASE_URL` via environment variable
- set default and pass env variable in docker-compose

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc1791fa8833199f64c83dee63ddc