### PR TITLE
Implement React CRUD pages

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,3 +1,28 @@
+import { useEffect, useState } from 'react';
+import api from '../api';
+
 export default function Dashboard() {
-  return <div>Dashboard</div>;
+  const [stats, setStats] = useState({ horses: 0, races: 0, tests: 0 });
+
+  useEffect(() => {
+    async function load() {
+      const [h, r, t] = await Promise.all([
+        api.get('/horses'),
+        api.get('/races'),
+        api.get('/drug-tests'),
+      ]);
+      setStats({ horses: h.data.length, races: r.data.length, tests: t.data.length });
+    }
+
+    load();
+  }, []);
+
+  return (
+    <div>
+      <h2>Dashboard</h2>
+      <p>Horses: {stats.horses}</p>
+      <p>Races: {stats.races}</p>
+      <p>Drug Tests: {stats.tests}</p>
+    </div>
+  );
 }

--- a/frontend/src/pages/DataGrid.jsx
+++ b/frontend/src/pages/DataGrid.jsx
@@ -1,3 +1,112 @@
+import { useState, useEffect, useCallback } from 'react';
+import api from '../api';
+
+const resources = {
+  horses: ['name', 'breed', 'age'],
+  races: ['name', 'date', 'location'],
+  'drug-tests': ['horse_id', 'race_id', 'result', 'date'],
+};
+
 export default function DataGrid() {
-  return <div>Data Grid</div>;
+  const [resource, setResource] = useState('horses');
+  const [items, setItems] = useState([]);
+  const [form, setForm] = useState({});
+  const [editingId, setEditingId] = useState(null);
+
+  const fetchItems = useCallback(async () => {
+    const res = await api.get(`/${resource}`);
+    setItems(res.data);
+  }, [resource]);
+
+  const resetForm = useCallback(() => {
+    const obj = {};
+    resources[resource].forEach((f) => {
+      obj[f] = '';
+    });
+    setForm(obj);
+  }, [resource]);
+
+  useEffect(() => {
+    fetchItems();
+    resetForm();
+  }, [resource, fetchItems, resetForm]);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (editingId) {
+      await api.put(`/${resource}/${editingId}`, form);
+    } else {
+      await api.post(`/${resource}`, form);
+    }
+    setEditingId(null);
+    resetForm();
+    fetchItems();
+  }
+
+  function startEdit(item) {
+    setEditingId(item.id);
+    const obj = {};
+    resources[resource].forEach((f) => {
+      obj[f] = item[f] || '';
+    });
+    setForm(obj);
+  }
+
+  async function deleteItem(id) {
+    await api.delete(`/${resource}/${id}`);
+    fetchItems();
+  }
+
+  return (
+    <div>
+      <h2>Admin Data Grid</h2>
+      <select value={resource} onChange={(e) => setResource(e.target.value)}>
+        {Object.keys(resources).map((r) => (
+          <option key={r} value={r}>
+            {r}
+          </option>
+        ))}
+      </select>
+
+      <form onSubmit={handleSubmit} style={{ margin: '1rem 0' }}>
+        {resources[resource].map((f) => (
+          <input
+            key={f}
+            placeholder={f}
+            value={form[f]}
+            onChange={(e) => setForm({ ...form, [f]: e.target.value })}
+          />
+        ))}
+        <button type="submit">{editingId ? 'Update' : 'Add'}</button>
+      </form>
+
+      <table>
+        <thead>
+          <tr>
+            {resources[resource].map((f) => (
+              <th key={f}>{f}</th>
+            ))}
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={item.id}>
+              {resources[resource].map((f) => (
+                <td key={f}>{item[f]}</td>
+              ))}
+              <td>
+                <button type="button" onClick={() => startEdit(item)}>
+                  Edit
+                </button>
+                <button type="button" onClick={() => deleteItem(item.id)}>
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
 }

--- a/frontend/src/pages/HorseProfile.jsx
+++ b/frontend/src/pages/HorseProfile.jsx
@@ -1,6 +1,50 @@
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import api from '../api';
 
 export default function HorseProfile() {
   const { id } = useParams();
-  return <div>Horse Profile {id}</div>;
+  const navigate = useNavigate();
+  const [horse, setHorse] = useState(null);
+
+  useEffect(() => {
+    async function fetchHorse() {
+      const res = await api.get(`/horses/${id}`);
+      setHorse(res.data);
+    }
+    fetchHorse();
+  }, [id]);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    await api.put(`/horses/${id}`, horse);
+    navigate('/horses');
+  }
+
+  if (!horse) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h2>Edit Horse</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          placeholder="Name"
+          value={horse.name}
+          onChange={(e) => setHorse({ ...horse, name: e.target.value })}
+        />
+        <input
+          placeholder="Breed"
+          value={horse.breed || ''}
+          onChange={(e) => setHorse({ ...horse, breed: e.target.value })}
+        />
+        <input
+          type="number"
+          placeholder="Age"
+          value={horse.age || ''}
+          onChange={(e) => setHorse({ ...horse, age: e.target.value })}
+        />
+        <button type="submit">Save</button>
+      </form>
+    </div>
+  );
 }

--- a/frontend/src/pages/Horses.jsx
+++ b/frontend/src/pages/Horses.jsx
@@ -1,3 +1,99 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import api from '../api';
+
 export default function Horses() {
-  return <div>All Horses</div>;
+  const [horses, setHorses] = useState([]);
+  const [form, setForm] = useState({ name: '', breed: '', age: '' });
+  const [editingId, setEditingId] = useState(null);
+
+  useEffect(() => {
+    fetchHorses();
+  }, []);
+
+  async function fetchHorses() {
+    const res = await api.get('/horses');
+    setHorses(res.data);
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (editingId) {
+      await api.put(`/horses/${editingId}`, form);
+    } else {
+      await api.post('/horses', form);
+    }
+    setForm({ name: '', breed: '', age: '' });
+    setEditingId(null);
+    fetchHorses();
+  }
+
+  function startEdit(horse) {
+    setEditingId(horse.id);
+    setForm({
+      name: horse.name || '',
+      breed: horse.breed || '',
+      age: horse.age || '',
+    });
+  }
+
+  async function deleteHorse(id) {
+    await api.delete(`/horses/${id}`);
+    fetchHorses();
+  }
+
+  return (
+    <div>
+      <h2>Horses</h2>
+      <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
+        <input
+          placeholder="Name"
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+        />
+        <input
+          placeholder="Breed"
+          value={form.breed}
+          onChange={(e) => setForm({ ...form, breed: e.target.value })}
+        />
+        <input
+          type="number"
+          placeholder="Age"
+          value={form.age}
+          onChange={(e) => setForm({ ...form, age: e.target.value })}
+        />
+        <button type="submit">{editingId ? 'Update' : 'Add'}</button>
+      </form>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Breed</th>
+            <th>Age</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {horses.map((h) => (
+            <tr key={h.id}>
+              <td>
+                <Link to={`/horses/${h.id}`}>{h.name}</Link>
+              </td>
+              <td>{h.breed}</td>
+              <td>{h.age}</td>
+              <td>
+                <button type="button" onClick={() => startEdit(h)}>
+                  Edit
+                </button>
+                <button type="button" onClick={() => deleteHorse(h.id)}>
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
 }

--- a/frontend/src/pages/Problems.jsx
+++ b/frontend/src/pages/Problems.jsx
@@ -1,3 +1,41 @@
+import { useEffect, useState } from 'react';
+import api from '../api';
+
 export default function Problems() {
-  return <div>Problems View</div>;
+  const [failedTests, setFailedTests] = useState([]);
+
+  useEffect(() => {
+    fetchProblems();
+  }, []);
+
+  async function fetchProblems() {
+    const res = await api.get('/drug-tests');
+    setFailedTests(res.data.filter((d) => d.result === 'fail'));
+  }
+
+  return (
+    <div>
+      <h2>Failed Drug Tests</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Horse</th>
+            <th>Race</th>
+            <th>Date</th>
+            <th>Result</th>
+          </tr>
+        </thead>
+        <tbody>
+          {failedTests.map((t) => (
+            <tr key={t.id}>
+              <td>{t.horse_id}</td>
+              <td>{t.race_id}</td>
+              <td>{t.date}</td>
+              <td>{t.result}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
 }

--- a/frontend/src/pages/Races.jsx
+++ b/frontend/src/pages/Races.jsx
@@ -1,3 +1,95 @@
+import { useState, useEffect } from 'react';
+import api from '../api';
+
 export default function Races() {
-  return <div>Races</div>;
+  const [races, setRaces] = useState([]);
+  const [form, setForm] = useState({ name: '', date: '', location: '' });
+  const [editingId, setEditingId] = useState(null);
+
+  useEffect(() => {
+    fetchRaces();
+  }, []);
+
+  async function fetchRaces() {
+    const res = await api.get('/races');
+    setRaces(res.data);
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (editingId) {
+      await api.put(`/races/${editingId}`, form);
+    } else {
+      await api.post('/races', form);
+    }
+    setForm({ name: '', date: '', location: '' });
+    setEditingId(null);
+    fetchRaces();
+  }
+
+  function startEdit(race) {
+    setEditingId(race.id);
+    setForm({
+      name: race.name || '',
+      date: race.date || '',
+      location: race.location || '',
+    });
+  }
+
+  async function deleteRace(id) {
+    await api.delete(`/races/${id}`);
+    fetchRaces();
+  }
+
+  return (
+    <div>
+      <h2>Races</h2>
+      <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
+        <input
+          placeholder="Name"
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+        />
+        <input
+          type="date"
+          value={form.date}
+          onChange={(e) => setForm({ ...form, date: e.target.value })}
+        />
+        <input
+          placeholder="Location"
+          value={form.location}
+          onChange={(e) => setForm({ ...form, location: e.target.value })}
+        />
+        <button type="submit">{editingId ? 'Update' : 'Add'}</button>
+      </form>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Date</th>
+            <th>Location</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {races.map((r) => (
+            <tr key={r.id}>
+              <td>{r.name}</td>
+              <td>{r.date}</td>
+              <td>{r.location}</td>
+              <td>
+                <button type="button" onClick={() => startEdit(r)}>
+                  Edit
+                </button>
+                <button type="button" onClick={() => deleteRace(r.id)}>
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add CRUD UI for horses and races
- implement a profile page to edit a single horse
- build an admin data grid to manage horses, races and drug tests
- show counts on the dashboard
- display failed drug tests on the problems page

## Testing
- `npm run lint`
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_687bc20207c0833192459dda1c0c48d8