### PR TITLE
Add API tests and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ The SQLite database file lives at `backend/db/data.db` (inside the container it 
 ### Admin UI and demo data
 
 The admin data grid is served at `http://localhost:3000/grid`. You can populate the app with sample content by toggling "Demo data" in the UI before initialization.
+
+### Running tests
+
+Unit tests live under `backend/app/tests`. Install backend dependencies and run
+pytest with `PYTHONPATH` pointing at the `backend` directory so the `app`
+package resolves correctly:
+
+```bash
+pip install -r backend/requirements.txt
+PYTHONPATH=backend pytest
+```

--- a/backend/app/tests/test_api_endpoints.py
+++ b/backend/app/tests/test_api_endpoints.py
@@ -1,0 +1,38 @@
+import os
+from pathlib import Path
+from fastapi.testclient import TestClient
+import pytest
+
+# Configure a temporary SQLite database for tests
+os.environ["SQLALCHEMY_DATABASE_URL"] = "sqlite:///./test_api.db"
+
+from app.main import app
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def teardown_module(module):
+    Path("test_api.db").unlink(missing_ok=True)
+
+
+def test_create_and_get_horse(client):
+    # Create a horse
+    response = client.post("/api/v1/horses/", json={"name": "Test Horse"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Test Horse"
+
+    horse_id = data["id"]
+
+    # Retrieve the same horse
+    get_resp = client.get(f"/api/v1/horses/{horse_id}")
+    assert get_resp.status_code == 200
+    get_data = get_resp.json()
+    assert get_data["id"] == horse_id
+    assert get_data["name"] == "Test Horse"
+
+


### PR DESCRIPTION
## Summary
- document how to run tests
- add a functional test for the horses API

## Testing
- `PYTHONPATH=backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc3670b388331b95d5d1606e4bb6d