### PR TITLE
Fix frontend container start command

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,4 +15,4 @@ services:
       - ../frontend:/app
     ports:
       - "3000:3000"
-    command: ./entrypoint.sh
+    command: sh /app/entrypoint.sh


### PR DESCRIPTION
## Summary
- ensure the frontend service runs entrypoint via `sh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bc5bae5908331ba73e939c06ef519