### PR TITLE
Fix Windows line endings for entrypoint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 sqlalchemy
 pydantic
 alembic
+httpx


### PR DESCRIPTION
## Summary
- enforce LF endings for shell scripts
- add httpx for backend tests

## Testing
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc8a168488331a842bfc6508dcf7e